### PR TITLE
Do not follow (bogus Samba4) referrals

### DIFF
--- a/root/etc/e-smith/templates/etc/roundcubemail/config.inc.php/50ADDRESSBOOK_SETTINGS
+++ b/root/etc/e-smith/templates/etc/roundcubemail/config.inc.php/50ADDRESSBOOK_SETTINGS
@@ -55,6 +55,7 @@ $OUT .= <<EOF;
     'bind_dn'                => '$bindDN',
     'bind_pass'              => '$quotedBindPass',
     'scope'                  => 'sub',
+    'referrals'              => 0,
 EOF
 
 if ($sssd->isLdap()) {


### PR DESCRIPTION
Workaround to Samba4 behavior. It returns ldap:// referrals even if the current connection is schema ldaps://

NethServer/dev#5161