### PR TITLE
Change temp_dir path to /var/tmp/

### DIFF
--- a/root/etc/e-smith/templates/etc/roundcubemail/config.inc.php/40SYSTEM
+++ b/root/etc/e-smith/templates/etc/roundcubemail/config.inc.php/40SYSTEM
@@ -30,7 +30,7 @@ $config['user_aliases'] = false;
 $config['log_dir'] = '/var/log/roundcubemail/';
 
 // use this folder to store temp files (must be writeable for apache user)
-$config['temp_dir'] = '$\{_tmppath\}';
+$config['temp_dir'] = '/var/tmp/';
 
 // lifetime of message cache
 // possible units: s, m, h, d, w


### PR DESCRIPTION
Roundcube sends mails without attachments because $config['temp_dir'] in /etc/roundcubemail/config.inc.php is set wrong.

Refs NethServer/dev#5397