### PR TITLE
conf: do not print grant command to log

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-roundcubemail-conf
+++ b/root/etc/e-smith/events/actions/nethserver-roundcubemail-conf
@@ -44,8 +44,6 @@ my $commands = join("\n",
 	      "CREATE DATABASE IF NOT EXISTS roundcubemail DEFAULT CHARACTER SET = 'utf8';"
      ) . "\n";
 
-print $commands;
-
 open(FH, '|-', '/usr/bin/mysql -B -f') || die("[ERROR] Could not connect to mysql");
 print FH $commands;     
 close(FH);


### PR DESCRIPTION
Avoid password leak inside the logs

Extract from log:
```
Jan 11 08:22:47 nstest esmith::event[4045]: GRANT ALL PRIVILEGES ON `roundcubemail`.* TO 'roundcubemail'@'localhost' IDENTIFIED BY 'MDy3Bih_Ww8Akhix';
Jan 11 08:22:47 nstest esmith::event[4045]: FLUSH PRIVILEGES;
Jan 11 08:22:47 nstest esmith::event[4045]: CREATE DATABASE IF NOT EXISTS roundcubemail DEFAULT CHARACTER SET = 'utf8';
```